### PR TITLE
[review]add gzip compression level option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+- Add gzip compression level option
+- Fix bug in Gzip command where level option was not appended correctly
+
 ## [0.10.0] - 2024-03-18
 
 - Fix loading YAML with ERB

--- a/lib/sg_tiny_backup/commands/gzip.rb
+++ b/lib/sg_tiny_backup/commands/gzip.rb
@@ -12,7 +12,7 @@ module SgTinyBackup
 
       def command
         parts = ["gzip"]
-        parts = "-#{@level}" if @level
+        parts << "-#{@level}" if @level
         parts.join(" ")
       end
     end

--- a/lib/sg_tiny_backup/config.rb
+++ b/lib/sg_tiny_backup/config.rb
@@ -11,16 +11,18 @@ module SgTinyBackup
     KEY_LOG = "log"
     KEY_FILES = "files"
     KEY_OPTIONAL_FILES = "optional_files"
+    KEY_GZIP = "gzip"
 
-    attr_reader :s3, :encryption_key, :pg_dump, :mysqldump, :db
+    attr_reader :s3, :encryption_key, :pg_dump, :mysqldump, :db, :gzip
 
-    def initialize(s3:, encryption_key:, pg_dump: nil, mysqldump: nil, db: nil, log: nil) # rubocop:disable Metrics/ParameterLists
+    def initialize(s3:, encryption_key:, pg_dump: nil, mysqldump: nil, db: nil, log: nil, gzip: nil) # rubocop:disable Metrics/ParameterLists
       @s3 = s3
       @encryption_key = encryption_key
       @pg_dump = pg_dump || {}
       @mysqldump = mysqldump
       @db = db || self.class.rails_db_config
       @log = log || {}
+      @gzip = gzip || {}
     end
 
     def log_file_paths
@@ -40,7 +42,8 @@ module SgTinyBackup
           db: yaml[KEY_DB],
           pg_dump: yaml[KEY_PG_DUMP],
           mysqldump: yaml[KEY_MYSQLDUMP],
-          log: yaml[KEY_LOG]
+          log: yaml[KEY_LOG],
+          gzip: yaml[KEY_GZIP]
         )
       end
 

--- a/lib/sg_tiny_backup/pipeline_builders/db.rb
+++ b/lib/sg_tiny_backup/pipeline_builders/db.rb
@@ -21,7 +21,7 @@ module SgTinyBackup
         output_path = base_filename if local?
         pl = Pipeline.new(output_path: output_path)
         pl << db_dump_command
-        pl << Commands::Gzip.new
+        pl << Commands::Gzip.new(level: @config.gzip["level"])
         pl << Commands::Openssl.new(password: @config.encryption_key)
         pl << aws_cli_command unless local?
         pl

--- a/lib/sg_tiny_backup/pipeline_builders/log.rb
+++ b/lib/sg_tiny_backup/pipeline_builders/log.rb
@@ -21,7 +21,7 @@ module SgTinyBackup
         output_path = base_filename if local?
         pl = Pipeline.new(output_path: output_path)
         pl << Commands::Tar.new(paths: @config.log_file_paths, optional_paths: @config.optional_log_file_paths)
-        pl << Commands::Gzip.new
+        pl << Commands::Gzip.new(level: @config.gzip["level"])
         pl << aws_cli_command unless local?
         pl
       end

--- a/lib/sg_tiny_backup/templates/sg_tiny_backup.yml
+++ b/lib/sg_tiny_backup/templates/sg_tiny_backup.yml
@@ -32,6 +32,8 @@ pg_dump:
   extra_options: -xc --if-exists --encoding=utf8
 mysqldump:
   extra_options: --single-transaction --quick --hex-blob
+# gzip:
+#   level: 6  # 1 (fastest) to 9 (best compression), default: 6
 # The following settings is not required since database config can be loaded from config/database.yml in typical rails application.
 # db:
 #   adapter: postgresql

--- a/spec/sg_tiny_backup/config_spec.rb
+++ b/spec/sg_tiny_backup/config_spec.rb
@@ -27,6 +27,40 @@ RSpec.describe SgTinyBackup::Config do
       expect(config.encryption_key).to eq "MY_ENCRYPTION_KEY"
     end
 
+    it "reads gzip config" do
+      yaml = <<~YAML
+        ---
+        s3:
+          bucket: my_bucket
+          prefix: my_prefix
+          access_key_id: MY_ACCESS_KEY_ID
+          secret_access_key: MY_SECRET_ACCESS_KEY
+        pg_dump:
+          extra_options: -xc --if-exists --encoding=utf8
+        gzip:
+          level: 1
+        encryption_key: MY_ENCRYPTION_KEY
+      YAML
+
+      config = SgTinyBackup::Config.read(StringIO.new(yaml))
+      expect(config.gzip).to eq({ "level" => 1 })
+    end
+
+    it "defaults gzip to empty hash when not specified" do
+      yaml = <<~YAML
+        ---
+        s3:
+          bucket: my_bucket
+          prefix: my_prefix
+          access_key_id: MY_ACCESS_KEY_ID
+          secret_access_key: MY_SECRET_ACCESS_KEY
+        encryption_key: MY_ENCRYPTION_KEY
+      YAML
+
+      config = SgTinyBackup::Config.read(StringIO.new(yaml))
+      expect(config.gzip).to eq({})
+    end
+
     it "reads an config file with erb" do
       yaml = <<~YAML
         ---

--- a/spec/sg_tiny_backup/runner_spec.rb
+++ b/spec/sg_tiny_backup/runner_spec.rb
@@ -46,6 +46,38 @@ RSpec.describe SgTinyBackup::Runner do
       expect(runner.base_filename).to eq "01234567.sql.gz.enc"
     end
 
+    it "generates postgresql database backup command with gzip level" do
+      yaml = <<~YAML
+        s3:
+          db:
+            bucket: my_bucket
+            prefix: backup/database
+            access_key_id: MY_ACCESS_KEY_ID
+            secret_access_key: MY_SECRET_ACCESS_KEY
+            expected_upload_size: 100000000000
+        pg_dump:
+          extra_options: -xc --if-exists --encoding=utf8
+        gzip:
+          level: 1
+        encryption_key: MY_ENCRYPTION_KEY
+        db:
+          adapter: postgresql
+          database: my_database
+          host: localhost
+          port: 15432
+          username: postgres
+          password: MY_DB_PASSWORD
+      YAML
+
+      config = SgTinyBackup::Config.read(StringIO.new(yaml))
+      runner = SgTinyBackup::Runner.new(config: config, basename: "01234567")
+      commands = runner.plain_commands
+      expect(commands[0]).to eq "pg_dump -xc --if-exists --encoding=utf8 --username=postgres --host=localhost --port=15432 my_database"
+      expect(commands[1]).to eq "gzip -1"
+      expect(commands[2]).to eq "openssl enc -aes-256-cbc -pbkdf2 -iter 10000 -pass env:SG_TINY_BACKUP_ENCRYPTION_KEY"
+      expect(commands[3]).to eq "aws s3 cp --expected-size 100000000000 - s3://my_bucket/backup/database_01234567.sql.gz.enc"
+    end
+
     it "generates mysql database backup command" do
       yaml = <<~YAML
         s3:
@@ -100,6 +132,31 @@ RSpec.describe SgTinyBackup::Runner do
       commands = runner.plain_commands
       expect(commands[0]).to eq "tar -c tmp/log/production.log tmp/log/production.log.1"
       expect(commands[1]).to eq "gzip"
+      expect(commands[2]).to eq "aws s3 cp - s3://my_bucket/backup/log_01234567.tar.gz"
+    end
+
+    it "generates log backup command with gzip level" do
+      yaml = <<~YAML
+        s3:
+          log:
+            bucket: my_bucket
+            prefix: backup/log
+            access_key_id: MY_ACCESS_KEY_ID
+            secret_access_key: MY_SECRET_ACCESS_KEY
+        gzip:
+          level: 1
+        log:
+          files:
+            - tmp/log/production.log
+          optional_files:
+            - tmp/log/production.log.1
+      YAML
+
+      config = SgTinyBackup::Config.read(StringIO.new(yaml))
+      runner = SgTinyBackup::Runner.new(config: config, target: "log", basename: "01234567")
+      commands = runner.plain_commands
+      expect(commands[0]).to eq "tar -c tmp/log/production.log tmp/log/production.log.1"
+      expect(commands[1]).to eq "gzip -1"
       expect(commands[2]).to eq "aws s3 cp - s3://my_bucket/backup/log_01234567.tar.gz"
     end
   end


### PR DESCRIPTION
Add configurable gzip compression level (1-9) via the `gzip.level` setting in sg_tiny_backup.yml. This allows users to control the trade-off between compression speed and file size.

Also fix a bug in the Gzip command where the level option was incorrectly assigned (`parts = ...`) instead of appended (`parts << ...`).